### PR TITLE
Allow artisanpack-ui/security ^2.0 (2.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # ArtisanPack UI Livewire UI Components
 
+## [2.0.3] - 2026-05-21
+
+### Changed
+- Updated `artisanpack-ui/security` constraint from `^1.0` to `^1.0|^2.0` to support ArtisanPack UI Security 2.0
+
+---
+
 ## [2.0.2] - 2026-03-02
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "artisanpack-ui/livewire-ui-components",
     "description": "A Livewire UI component library for the TALL stack, forked from MaryUI and adapted for the ArtisanPack UI ecosystem.",
     "license": "MIT",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "authors": [
         {
             "name": "Jacob Martella",
@@ -38,7 +38,7 @@
         "blade-ui-kit/blade-heroicons": "^2.0",
         "livewire/livewire": "^3.6|^4.0",
         "artisanpack-ui/accessibility": "^2.0.0",
-        "artisanpack-ui/security": "^1.0",
+        "artisanpack-ui/security": "^1.0|^2.0",
         "owenvoke/blade-fontawesome": "^2.9",
         "artisanpack-ui/core": "^1.0",
         "artisanpack-ui/icons": "^2.0"


### PR DESCRIPTION
Widens the artisanpack-ui/security   constraint from ^1.0 to ^1.0|^2.0 so this package installs alongside Security 2.0. Bumps to   2.0.3 + CHANGELOG. Unblocks downstream consumers (e.g. security-full, which requires security   ^2.0) that currently can't resolve because livewire-ui-components pins security ^1.0. Strictly   more permissive — existing ^1.0 consumers unaffected. Constraint-only, no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.0.3 with expanded compatibility for supported dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/livewire-ui-components/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->