### PR TITLE
Release v2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # ArtisanPack UI Livewire UI Components
 
+## [2.0.4] - Unreleased
+
+### Changed
+- Added Laravel 13 support by widening `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0`
+- Widened `orchestra/testbench` dev constraint to `^8|^9|^10|^11` to enable testing against Laravel 13
+
+---
+
 ## [2.0.3] - 2026-05-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # ArtisanPack UI Livewire UI Components
 
-## [2.0.4] - Unreleased
+## [Unreleased]
+
+---
+
+## [2.0.4] - 2026-06-09
 
 ### Changed
 - Added Laravel 13 support by widening `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Added Laravel 13 support by widening `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0`
 - Widened `orchestra/testbench` dev constraint to `^8|^9|^10|^11` to enable testing against Laravel 13
+- Added explicit `php` constraint of `^8.1` so Composer fails fast on unsupported PHP versions (the floor matches Laravel 10's PHP requirement; Laravel 11/12/13 transitively enforce higher floors)
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "alpinejs"
     ],
     "require": {
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "jfcherng/php-diff": "^6.15",
         "laravel/prompts": "^0|^1",
         "blade-ui-kit/blade-heroicons": "^2.0",
@@ -48,7 +48,7 @@
         "barryvdh/laravel-dompdf": "Required for PDF export functionality in Table component (^3.0)"
     },
     "require-dev": {
-        "orchestra/testbench": "^8|^9|^10",
+        "orchestra/testbench": "^8|^9|^10|^11",
         "pestphp/pest": "^3.5",
         "pestphp/pest-plugin-laravel": "^3.0",
         "pestphp/pest-plugin-type-coverage": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "alpinejs"
     ],
     "require": {
+        "php": "^8.1",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "jfcherng/php-diff": "^6.15",
         "laravel/prompts": "^0|^1",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "artisanpack-ui/livewire-ui-components",
     "description": "A Livewire UI component library for the TALL stack, forked from MaryUI and adapted for the ArtisanPack UI ecosystem.",
     "license": "MIT",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "authors": [
         {
             "name": "Jacob Martella",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddf58e38daccb22f072aebfbbd2bcc3e",
+    "content-hash": "7b63957bb2cfb879929a0261741c7102",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -13774,5 +13774,5 @@
         "ext-dom": "*",
         "ext-libxml": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9274f8bb0613d3a99efa52de0d2bc10a",
+    "content-hash": "680ffc76a28039989772ba24483993d7",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b63957bb2cfb879929a0261741c7102",
+    "content-hash": "9274f8bb0613d3a99efa52de0d2bc10a",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -13769,7 +13769,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": "^8.1"
+    },
     "platform-dev": {
         "ext-dom": "*",
         "ext-libxml": "*"


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.0.4
- **Release Date:** 2026-06-09
- **Release Type:** Patch
- **Release Branch:** `release/2.0.4`
- **Target Branch:** `main`

## Release Summary

Patch release that adds Laravel 13 support. The framework constraint is widened additively — Laravel 10, 11, and 12 continue to be fully supported, and users only get Laravel 13 if they're on PHP 8.3+ (enforced transitively by Laravel 13's own constraints). An explicit `php: ^8.1` floor was added to make resolution failures fail fast with a clear error.

## Changelog

### Added
- N/A

### Changed
- Added Laravel 13 support by widening `illuminate/support` constraint to `^10.0|^11.0|^12.0|^13.0`
- Widened `orchestra/testbench` dev constraint to `^8|^9|^10|^11` to enable testing against Laravel 13
- Added explicit `php` constraint of `^8.1` so Composer fails fast on unsupported PHP versions (the floor matches Laravel 10's PHP requirement; Laravel 11/12/13 transitively enforce higher floors)

### Deprecated
- N/A

### Removed
- N/A

### Fixed
- N/A

### Security
- N/A

## Issues and Pull Requests

**Issues Fixed:**
- Closes #100

**Related PRs:**
- #101 (enhancement/100-add-laravel-13-support)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking changes:** None — change is purely additive (widens an accepted version range).

**Migration guide:** N/A — no action required for existing users. Users on Laravel 10/11/12 continue to work without changes.

## Testing Checklist

- [x] All automated tests passing (within the project's current CI policy — pre-existing test failures are non-blocking per [PR #99](https://github.com/ArtisanPack-UI/livewire-ui-components/pull/99), tracked separately from this release)
- [x] Manual testing completed
- [ ] Accessibility tests passing (N/A — composer constraint change only)
- [ ] Performance tests passing (N/A)
- [x] Security scan completed (see Dependency Notes below)
- [ ] Tested in staging environment (N/A for package release)
- [ ] Database migrations tested (N/A)

**Testing notes:**

- `composer validate` is clean (only the project's intentional `version` field warning remains)
- `composer update --lock` resolves cleanly with no installed-version changes
- `./vendor/bin/pint --dirty` clean
- Full Pest suite executed; failure count is identical to the pre-release-prep `release/2.0.4` HEAD — no new regressions introduced by this release prep

## Documentation Checklist

- [x] CHANGELOG updated (2.0.4 entry dated 2026-06-09; empty `[Unreleased]` section added above)
- [ ] README updated (N/A — no README content changed)
- [ ] API documentation updated (N/A)
- [ ] Migration guide written (N/A — no breaking changes)
- [x] Release notes written (this PR)
- [ ] Wiki updated (no wiki changes needed)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json`: 2.0.3 → 2.0.4; no other project-version refs exist — theme-config schema versions and `@since` history tags intentionally untouched)
- [x] Git tag prepared: `v2.0.4` (to be created on merge)
- [x] Release branch created/updated: `release/2.0.4`
- [x] Dependencies updated and tested
- [ ] Build artifacts generated (N/A — Composer package)
- [x] Deployment plan reviewed
- [x] Rollback plan prepared
- [ ] Stakeholders notified

## Deployment

**Deployment steps:**
1. Merge this PR into `main`
2. Tag the merge commit on `main` as `v2.0.4`
3. The release workflow (`.github/workflows/release.yml`) publishes to Packagist on tag

**Rollback plan:**
1. If a regression is reported post-release, revert the merge commit on `main` and tag a `v2.0.5` patch with the revert.
2. Packagist will pick up the new tag automatically; users can pin to `2.0.3` until then.

**Configuration changes:** None.

**Environment variables:** None.

## Post-Release Tasks

- [ ] Tag created: `v2.0.4`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Announcement sent
- [ ] Monitoring verified
- [ ] Previous version support documented

## Dependency Notes

**Lock file:** in sync with `composer.json` after `composer update --lock`.

**Outdated direct dependencies (informational, not blocking this release):**

The following direct dependencies have newer versions available but are intentionally left at their current constraints — they're either widening targets (Livewire, testbench, Laravel) already covered by composer's range resolution, or major-version bumps that would be breaking changes tracked separately:

- `artisanpack-ui/accessibility`: 2.1.0 → 2.1.2 (patch)
- `artisanpack-ui/code-style`: 1.1.0 → 1.1.1 (patch)
- `artisanpack-ui/code-style-pint`: 1.1.0 → 1.1.1 (patch)
- `artisanpack-ui/core`: 1.0.0 → 1.2.0 (minor)
- `artisanpack-ui/security`: 1.0.3 → 2.0.1 (already widened to `^1.0|^2.0`)
- `blade-ui-kit/blade-heroicons`: 2.6.0 → 2.7.0 (minor)
- `livewire/livewire`: 3.7.0 → 4.3.1 (already widened to `^3.6|^4.0`)
- `owenvoke/blade-fontawesome`: 2.9.1 → 3.2.2 (major — separate concern)
- `jfcherng/php-diff`: 6.16.2 → 7.0.0 (major — separate concern)

**Security scan results (`composer audit`):**

| Package | Severity | Source |
|---|---|---|
| `symfony/routing` (CVE-2026-48784) | Unspecified | Transitive via Laravel framework |
| `symfony/routing` (CVE-2026-45065) | Medium | Transitive via Laravel framework |
| `symfony/yaml` (CVE-2026-45133) | Low | Transitive via Laravel framework (dev only) |

All flagged advisories are **transitive** via Laravel framework. Resolution requires upgrading the host application's Laravel installation, not changes to this package. Not blocking this release.

Abandoned: `pestphp/pest-plugin-watch` (dev-only) — flagged for future cleanup, no replacement currently suggested upstream.

## Notes

This is a small, targeted release: a single feature (Laravel 13 support) cleanly merged via PR #101. CodeRabbit review on PR #101 came back with no actionable comments after the explicit `php` constraint was added.

---

**Release Manager:** @jacobmartella

**For Reviewers:**
- Verify version: 2.0.4 in `composer.json`, dated 2026-06-09 in CHANGELOG.md
- Confirm the framework-range widen is the only intended behavior change
- Confirm no breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 2.0.4 released. Extended Laravel support to include Laravel 13 alongside Laravel 10, 11, and 12. Testing framework compatibility expanded for newer environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->