### PR TITLE
enhancement: widen owenvoke/blade-fontawesome to ^2.9|^3.0 for Laravel 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,27 +54,35 @@ jobs:
         include:
           - php: '8.2'
             laravel: '10.*'
+            testbench: '8.*'
             fontawesome: '^2.9'
           - php: '8.2'
             laravel: '11.*'
+            testbench: '9.*'
             fontawesome: '^2.9'
           - php: '8.2'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^2.9'
           - php: '8.3'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^2.9'
           - php: '8.3'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^3.0'
           - php: '8.3'
             laravel: '13.*'
+            testbench: '11.*'
             fontawesome: '^3.0'
           - php: '8.4'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^3.0'
           - php: '8.4'
             laravel: '13.*'
+            testbench: '11.*'
             fontawesome: '^3.0'
 
     steps:
@@ -95,13 +103,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: |
           composer require \
-            "illuminate/support:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}" \
+            --dev --no-interaction --no-update
+          composer require \
             "owenvoke/blade-fontawesome:${{ matrix.fontawesome }}" \
             --no-interaction --no-update
           composer update --no-interaction --prefer-dist --with-all-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,45 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }} / FA ${{ matrix.fontawesome }}
     continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.2'
+            laravel: '10.*'
+            fontawesome: '^2.9'
+          - php: '8.2'
+            laravel: '11.*'
+            fontawesome: '^2.9'
+          - php: '8.2'
+            laravel: '12.*'
+            fontawesome: '^2.9'
+          - php: '8.3'
+            laravel: '12.*'
+            fontawesome: '^2.9'
+          - php: '8.3'
+            laravel: '12.*'
+            fontawesome: '^3.0'
+          - php: '8.3'
+            laravel: '13.*'
+            fontawesome: '^3.0'
+          - php: '8.4'
+            laravel: '12.*'
+            fontawesome: '^3.0'
+          - php: '8.4'
+            laravel: '13.*'
+            fontawesome: '^3.0'
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -66,11 +95,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: |
+          composer require \
+            "illuminate/support:${{ matrix.laravel }}" \
+            "owenvoke/blade-fontawesome:${{ matrix.fontawesome }}" \
+            --no-interaction --no-update
+          composer update --no-interaction --prefer-dist --with-all-dependencies
 
       - name: Run Unit tests
         env:

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "livewire/livewire": "^3.6|^4.0",
         "artisanpack-ui/accessibility": "^2.0.0",
         "artisanpack-ui/security": "^1.0|^2.0",
-        "owenvoke/blade-fontawesome": "^2.9",
+        "owenvoke/blade-fontawesome": "^2.9|^3.0",
         "artisanpack-ui/core": "^1.0",
         "artisanpack-ui/icons": "^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "680ffc76a28039989772ba24483993d7",
+    "content-hash": "31aafd6e0f70ec450359c063f648b356",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -3248,29 +3248,29 @@
         },
         {
             "name": "owenvoke/blade-fontawesome",
-            "version": "v2.9.1",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/owenvoke/blade-fontawesome.git",
-                "reference": "94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1"
+                "reference": "5a199630dd70c5133d58c158a974e12bcd8b3a71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/owenvoke/blade-fontawesome/zipball/94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1",
-                "reference": "94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1",
+                "url": "https://api.github.com/repos/owenvoke/blade-fontawesome/zipball/5a199630dd70c5133d58c158a974e12bcd8b3a71",
+                "reference": "5a199630dd70c5133d58c158a974e12bcd8b3a71",
                 "shasum": ""
             },
             "require": {
-                "blade-ui-kit/blade-icons": "^1.5",
-                "illuminate/support": "^10.34|^11.0|^12.0",
-                "php": "^8.1"
+                "blade-ui-kit/blade-icons": "^1.8",
+                "illuminate/support": "^12.0|^13.0",
+                "php": "^8.3"
             },
             "require-dev": {
-                "laravel/pint": "^1.13",
-                "orchestra/testbench": "^8.12|^9.0|^10.0",
-                "pestphp/pest": "^2.26|^3.7",
-                "phpstan/phpstan": "^1.10|^2.1",
-                "symfony/var-dumper": "^6.3|^7.2"
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^4.1",
+                "phpstan/phpstan": "^2.1",
+                "symfony/var-dumper": "^7.3"
             },
             "type": "library",
             "extra": {
@@ -3292,7 +3292,7 @@
             "description": "A package to easily make use of Font Awesome in your Laravel Blade views",
             "support": {
                 "issues": "https://github.com/owenvoke/blade-fontawesome/issues",
-                "source": "https://github.com/owenvoke/blade-fontawesome/tree/v2.9.1"
+                "source": "https://github.com/owenvoke/blade-fontawesome/tree/v3.2.2"
             },
             "funding": [
                 {
@@ -3304,7 +3304,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-28T16:03:42+00:00"
+            "time": "2026-03-20T08:37:22+00:00"
         },
         {
             "name": "phpoption/phpoption",


### PR DESCRIPTION
## Description

Widens the `owenvoke/blade-fontawesome` constraint from `^2.9` to `^2.9|^3.0`. The previous `^2.9` pin transitively capped `illuminate/support` at `^12.0` (via blade-fontawesome v2.9.1), which propagated up and blocked Laravel 13 in downstream consumers. blade-fontawesome v3.2.2 declares `illuminate/support: ^12.0|^13.0`, so widening the constraint removes the cap while remaining backwards compatible — existing v2.9 installs still resolve.

**Closes:** #103

## Type of Change

- [x] Enhancement (improves existing functionality)

## Related Issue

**Issue:** #103

## Motivation and Context

Final blocker in the Laravel 13 support initiative. Follows compliance#15, security-advanced-auth#15, and security-analytics#17 (all shipped as 1.0.1). Without this widening, `artisanpack-ui/forms` and `artisanpack-ui/media-library` consumers (e.g. Keystone CMS) cannot move to Laravel 13.

## Changes Made

- `composer.json`: `owenvoke/blade-fontawesome` constraint widened from `^2.9` to `^2.9|^3.0`
- `composer.lock`: regenerated; blade-fontawesome bumps to v3.2.2 on a fresh resolve
- `.github/workflows/ci.yml`: test job converted to a matrix covering PHP 8.2/8.3/8.4 × Laravel 10/11/12/13 × blade-fontawesome v2/v3, so framework version bumps are exercised by CI going forward

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (darwin 25.5.0)
- PHP Version: 8.4.3
- Project Version: 2.0.5 release branch

**Tests Performed:**
1. Static audit (Explore subagent, medium thoroughness): zero usages of `<x-fas-*>`, `<x-far-*>`, `<x-fab-*>`, `<x-fad-*>`, `<x-fal-*>`, `<x-fat-*>`, `<x-fass-*>` Blade components or `OwenVoke\BladeFontAwesome` namespace anywhere in `src/`, `resources/`, `config/`, or `tests/`. Package is a transitive dep only — v2→v3 API change has no surface area in this codebase.
2. Pest suite on this branch vs. `release/2.0.5`: identical results (2106 tests, 56 errors, 84 failures, 866 skipped). All failures pre-existing on the base branch; no regressions introduced by this change.
3. `composer validate` passes.
4. `composer update owenvoke/blade-fontawesome` cleanly resolves to v3.2.2.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — constraint-only change with no UI surface.

## Tests Added

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing (no new failures vs. base; pre-existing failures unchanged)

**Test details:** CI matrix expansion exercises Laravel 10/11/12/13 × blade-fontawesome v2/v3 combinations going forward.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** N/A — dependency constraint widening only.

## Screenshots

N/A — no UI change.

## Pre-Submission Checklist

- [x] Checked for other open PRs for same update
- [x] Code passes all tests (no regressions vs. base)
- [x] No new warnings generated
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the CI pipeline to run the test suite across multiple PHP (8.2–8.4) and Laravel (10–13) versions.
* **Chores**
  * Added support for running tests without failing fast to better surface issues across the full matrix.
* **Dependencies**
  * Expanded FontAwesome Blade dependency support to allow version 3.0 in addition to 2.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->