### PR TITLE
Release v2.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,27 +54,35 @@ jobs:
         include:
           - php: '8.2'
             laravel: '10.*'
+            testbench: '8.*'
             fontawesome: '^2.9'
           - php: '8.2'
             laravel: '11.*'
+            testbench: '9.*'
             fontawesome: '^2.9'
           - php: '8.2'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^2.9'
           - php: '8.3'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^2.9'
           - php: '8.3'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^3.0'
           - php: '8.3'
             laravel: '13.*'
+            testbench: '11.*'
             fontawesome: '^3.0'
           - php: '8.4'
             laravel: '12.*'
+            testbench: '10.*'
             fontawesome: '^3.0'
           - php: '8.4'
             laravel: '13.*'
+            testbench: '11.*'
             fontawesome: '^3.0'
 
     steps:
@@ -95,13 +103,15 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: |
           composer require \
-            "illuminate/support:${{ matrix.laravel }}" \
+            "orchestra/testbench:${{ matrix.testbench }}" \
+            --dev --no-interaction --no-update
+          composer require \
             "owenvoke/blade-fontawesome:${{ matrix.fontawesome }}" \
             --no-interaction --no-update
           composer update --no-interaction --prefer-dist --with-all-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,45 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }} / FA ${{ matrix.fontawesome }}
     continue-on-error: true
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - php: '8.2'
+            laravel: '10.*'
+            fontawesome: '^2.9'
+          - php: '8.2'
+            laravel: '11.*'
+            fontawesome: '^2.9'
+          - php: '8.2'
+            laravel: '12.*'
+            fontawesome: '^2.9'
+          - php: '8.3'
+            laravel: '12.*'
+            fontawesome: '^2.9'
+          - php: '8.3'
+            laravel: '12.*'
+            fontawesome: '^3.0'
+          - php: '8.3'
+            laravel: '13.*'
+            fontawesome: '^3.0'
+          - php: '8.4'
+            laravel: '12.*'
+            fontawesome: '^3.0'
+          - php: '8.4'
+            laravel: '13.*'
+            fontawesome: '^3.0'
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PHP
+      - name: Setup PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -66,11 +95,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.fontawesome }}-
 
       - name: Install dependencies
-        run: composer install --no-interaction --prefer-dist
+        run: |
+          composer require \
+            "illuminate/support:${{ matrix.laravel }}" \
+            "owenvoke/blade-fontawesome:${{ matrix.fontawesome }}" \
+            --no-interaction --no-update
+          composer update --no-interaction --prefer-dist --with-all-dependencies
 
       - name: Run Unit tests
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ---
 
+## [2.0.5] - 2026-06-14
+
+### Changed
+- Widened `owenvoke/blade-fontawesome` constraint from `^2.9` to `^2.9|^3.0` to unblock Laravel 13 adoption in downstream consumers (the v2.9 line transitively caps `illuminate/support` at `^12.0`; v3.2.2 declares `^12.0|^13.0`). Backwards compatible — existing v2.9 installs continue to resolve. (#103)
+
+### CI
+- Expanded the CI `test` job into a PHP × Laravel × blade-fontawesome matrix covering L10–L13 on PHP 8.2–8.4 with both blade-fontawesome v2 and v3, so future framework bumps are exercised before tag. Matrix is informational-only for this release (see #105 for the gating cleanup).
+
+---
+
 ## [2.0.4] - 2026-06-09
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "artisanpack-ui/livewire-ui-components",
     "description": "A Livewire UI component library for the TALL stack, forked from MaryUI and adapted for the ArtisanPack UI ecosystem.",
     "license": "MIT",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "authors": [
         {
             "name": "Jacob Martella",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "livewire/livewire": "^3.6|^4.0",
         "artisanpack-ui/accessibility": "^2.0.0",
         "artisanpack-ui/security": "^1.0|^2.0",
-        "owenvoke/blade-fontawesome": "^2.9",
+        "owenvoke/blade-fontawesome": "^2.9|^3.0",
         "artisanpack-ui/core": "^1.0",
         "artisanpack-ui/icons": "^2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "31aafd6e0f70ec450359c063f648b356",
+    "content-hash": "bc0255b3560c41a80fd761312a5ad87c",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "680ffc76a28039989772ba24483993d7",
+    "content-hash": "31aafd6e0f70ec450359c063f648b356",
     "packages": [
         {
             "name": "artisanpack-ui/accessibility",
@@ -3248,29 +3248,29 @@
         },
         {
             "name": "owenvoke/blade-fontawesome",
-            "version": "v2.9.1",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/owenvoke/blade-fontawesome.git",
-                "reference": "94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1"
+                "reference": "5a199630dd70c5133d58c158a974e12bcd8b3a71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/owenvoke/blade-fontawesome/zipball/94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1",
-                "reference": "94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1",
+                "url": "https://api.github.com/repos/owenvoke/blade-fontawesome/zipball/5a199630dd70c5133d58c158a974e12bcd8b3a71",
+                "reference": "5a199630dd70c5133d58c158a974e12bcd8b3a71",
                 "shasum": ""
             },
             "require": {
-                "blade-ui-kit/blade-icons": "^1.5",
-                "illuminate/support": "^10.34|^11.0|^12.0",
-                "php": "^8.1"
+                "blade-ui-kit/blade-icons": "^1.8",
+                "illuminate/support": "^12.0|^13.0",
+                "php": "^8.3"
             },
             "require-dev": {
-                "laravel/pint": "^1.13",
-                "orchestra/testbench": "^8.12|^9.0|^10.0",
-                "pestphp/pest": "^2.26|^3.7",
-                "phpstan/phpstan": "^1.10|^2.1",
-                "symfony/var-dumper": "^6.3|^7.2"
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^4.1",
+                "phpstan/phpstan": "^2.1",
+                "symfony/var-dumper": "^7.3"
             },
             "type": "library",
             "extra": {
@@ -3292,7 +3292,7 @@
             "description": "A package to easily make use of Font Awesome in your Laravel Blade views",
             "support": {
                 "issues": "https://github.com/owenvoke/blade-fontawesome/issues",
-                "source": "https://github.com/owenvoke/blade-fontawesome/tree/v2.9.1"
+                "source": "https://github.com/owenvoke/blade-fontawesome/tree/v3.2.2"
             },
             "funding": [
                 {
@@ -3304,7 +3304,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-28T16:03:42+00:00"
+            "time": "2026-03-20T08:37:22+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/docs/home.md
+++ b/docs/home.md
@@ -27,7 +27,7 @@ ArtisanPack UI Livewire Components is a powerful UI component library for Larave
 
 ### Technology Stack
 
-- **Laravel 10, 11, 12, & 13**: Compatible with Laravel 10.x through 13.x
+- **Laravel 12 & 13**: The installer enforces Laravel 12 or newer; the package itself is compatible with Laravel 12.x and 13.x
 - **Livewire 3 & 4**: Utilizes Livewire for dynamic, reactive components with version-specific features
 - **Tailwind CSS 4**: Uses Tailwind CSS for styling
 - **DaisyUI**: Integrates with DaisyUI for additional styling and components

--- a/docs/home.md
+++ b/docs/home.md
@@ -27,7 +27,7 @@ ArtisanPack UI Livewire Components is a powerful UI component library for Larave
 
 ### Technology Stack
 
-- **Laravel 10, 11, & 12**: Compatible with Laravel 10.x and later
+- **Laravel 10, 11, 12, & 13**: Compatible with Laravel 10.x through 13.x
 - **Livewire 3 & 4**: Utilizes Livewire for dynamic, reactive components with version-specific features
 - **Tailwind CSS 4**: Uses Tailwind CSS for styling
 - **DaisyUI**: Integrates with DaisyUI for additional styling and components

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ This guide will walk you through the process of installing and configuring Artis
 
 Before installing ArtisanPack UI Livewire Components, ensure your environment meets the following requirements:
 
-- **Laravel 10–13**: Compatible with Laravel 10.x through 13.x
+- **Laravel 12 or 13**: The installer requires Laravel 12 or newer (verified at install time); the package itself is compatible with Laravel 12.x and 13.x
 - **PHP 8.1+**: PHP 8.1 or newer is required
 - **Node.js and NPM/Yarn/Bun/PNPM**: Required for compiling assets
 - **Composer**: Required for installing the package

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ This guide will walk you through the process of installing and configuring Artis
 
 Before installing ArtisanPack UI Livewire Components, ensure your environment meets the following requirements:
 
-- **Laravel 12+**: The package is designed for Laravel 12 or newer
+- **Laravel 10–13**: Compatible with Laravel 10.x through 13.x
 - **PHP 8.1+**: PHP 8.1 or newer is required
 - **Node.js and NPM/Yarn/Bun/PNPM**: Required for compiling assets
 - **Composer**: Required for installing the package


### PR DESCRIPTION
## Release Information

- **Release Version:** v2.0.5
- **Release Date:** 2026-06-14
- **Release Type:** Patch
- **Release Branch:** `release/2.0.5`
- **Target Branch:** `main`

## Release Summary

Patch release that unblocks Laravel 13 adoption for downstream consumers (Keystone CMS, `artisanpack-ui/forms`, `artisanpack-ui/media-library`).

2.0.4 widened the package's own `illuminate/support` constraint to accept Laravel 13, but `owenvoke/blade-fontawesome ^2.9` transitively capped `illuminate/support` at `^12.0`, propagating that cap back up and blocking Laravel 13 in consumers. 2.0.5 widens the blade-fontawesome constraint to `^2.9|^3.0` so `blade-fontawesome v3.2.2` (which declares `illuminate/support: ^12.0|^13.0`) can be resolved.

Final blocker in the Laravel 13 support initiative, following compliance#15, security-advanced-auth#15, and security-analytics#17 (all shipped as 1.0.1).

## Changelog

### Changed
- Widened `owenvoke/blade-fontawesome` constraint from `^2.9` to `^2.9|^3.0` to unblock Laravel 13 adoption in downstream consumers. Backwards compatible — existing v2.9 installs continue to resolve. (#103)

### CI
- Expanded the CI `test` job into a PHP × Laravel × blade-fontawesome matrix covering L10–L13 on PHP 8.2–8.4 with both blade-fontawesome v2 and v3. **Informational-only** for this release — `continue-on-error: true` is still on the test job because of the pre-existing 137-test backlog. Gating cleanup tracked in #105.

### Deprecated / Removed / Fixed / Security
- None.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #103

**Related PRs:**
- #104 (constraint widening + initial CI matrix)

**Follow-ups (NOT blocking this release):**
- #105 — CI matrix hygiene: skip advisory-blocked Laravel patches, gate L13 boost/volt, restore test gating

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

This release is a dependency constraint widening only. Audit confirmed zero in-repo usages of `blade-fontawesome` icons or namespace anywhere in `src/`, `resources/`, `config/`, or `tests/` — the v2→v3 API change has no surface area in this codebase.

## Testing Checklist

- [x] Automated tests run (see Testing notes)
- [x] Manual testing N/A — constraint-only change with no UI surface
- [x] Accessibility tests N/A — no UI changes
- [x] Performance tests N/A — no runtime changes
- [x] Security scan completed (see notes)
- [ ] Tested in staging environment
- [x] Database migrations N/A — none in this release

**Testing notes:**
- **pest**: 2106 tests, 56 errors, 84 failures, 866 skipped — **identical** results on `release/2.0.5` pre-PR and post-PR, confirming zero net new failures from 2.0.5. Pre-existing 140-failure backlog tracked in #105.
- **build job (CI)**: ✅ resolves cleanly with the widened constraint and lands `blade-fontawesome v3.2.2`.
- **CI matrix**: 8 combinations, all currently failing for known reasons (pre-existing test failures on L12 combos; advisory-blocked early Laravel patches on L10/L11; missing L13 support in `laravel/boost` and `livewire/volt` for L13 combos). All tracked in #105.

## Documentation Checklist

- [x] CHANGELOG updated (`[Unreleased]` promoted to `[2.0.5] - 2026-06-14`)
- [x] README — no version-specific text required updates
- [x] API documentation — no API changes
- [x] Migration guide — none required (no breaking changes)
- [x] Release notes — captured in changelog and this PR
- [x] docs/ — `docs/home.md` and `docs/installation.md` Laravel version callouts refreshed to L10–L13

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json` 2.0.4 → 2.0.5)
- [x] Git tag prepared: `v2.0.5` (post-merge)
- [x] Release branch updated: `release/2.0.5`
- [x] Dependencies audited (lock synced, advisories noted, no blockers)
- [x] Build artifacts — N/A (Composer package)
- [x] Deployment plan — Packagist publishes automatically on tag push
- [x] Rollback plan — yank tag from GitHub, deprecate on Packagist if necessary

## Deployment

**Deployment steps:**
1. Merge this PR into `main`
2. Tag `v2.0.5` on the merge commit and push
3. Verify Packagist picks up the new release
4. Notify downstream consumers (Keystone CMS, `artisanpack-ui/forms`, `artisanpack-ui/media-library`) that they can move to Laravel 13

**Rollback plan:**
1. Delete the `v2.0.5` tag locally and on the remote
2. Trigger a Packagist refresh to drop the release
3. Consumers can pin `~2.0.4` until a fixed release

**Configuration changes:** None.

**Environment variables:** None.

## Post-Release Tasks

- [ ] Tag created: `v2.0.5`
- [ ] Release notes published on GitHub Releases
- [ ] Documentation deployed (docs/home.md + docs/installation.md updates land with merge)
- [ ] Announcement sent to ArtisanPack-UI ecosystem
- [ ] Monitoring verified — N/A for a library release
- [ ] Previous version support documented — 2.0.4 remains compatible with L10/11/12 but not L13

## Dependency Notes

- **18 transitive security advisories** (all `symfony/*` via Laravel) — pre-existing on 2.0.4, clear when Laravel patches; not introduced by this release.
- **1 abandoned dev dep**: `pestphp/pest-plugin-watch` (no suggested replacement; dev-only, non-blocking).
- **23 outdated direct deps** — all dev tooling (Pint, Pest 3→4, PHPStan, etc.); none blocking. Queue for a future maintenance release.

## Notes

This is the final blocker in the Laravel 13 support initiative across the ArtisanPack-UI ecosystem. Once merged and tagged, downstream consumers can move to Laravel 13.

---

**Release Manager:** @ViewFromTheBox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Laravel 13.
  * Expanded compatibility with Blade FontAwesome v3 (while retaining v2 support).

* **Documentation**
  * Updated installation and documentation to reflect the Laravel 12+ requirements (installer checks for Laravel 12/13) and current Blade FontAwesome support.

* **Tests**
  * Improved CI coverage by running the test suite across a PHP × Laravel × Blade FontAwesome version matrix (PHP 8.2–8.4, Laravel 10–13, FontAwesome v2/v3).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->